### PR TITLE
feat: allow sending a file without defining a passphrase

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -61,12 +61,12 @@
         </div>
 
         <div class='section-header flex-row'>
-          <h3>Enter a passphrase</h3>
+          <h3>Enter a passphrase (optional)</h3>
           <span>Character limit: 172</span>
         </div>
         <div>
           <div class='password-wrapper'>
-            <input aria-label='Passphrase' id='passphrase' autocomplete='off' required name='passphrase' type='password' placeholder='Enter your passphrase'>
+            <input aria-label='Passphrase' id='passphrase' autocomplete='off' name='passphrase' type='password' placeholder='Enter your passphrase'>
             <button type='button' class='toggle-eye' aria-label='Show passphrase'>👁</button>
           </div>
         </div>

--- a/src/index.js
+++ b/src/index.js
@@ -66,7 +66,13 @@ document.addEventListener('DOMContentLoaded', function() {
       const text = form.querySelector('textarea').value;
 
       // get passphrase
-      const passphrase = document.querySelector('input[name="passphrase"]').value;
+      let passphraseInUrl = '';
+      let passphrase = document.querySelector('input[name="passphrase"]').value;
+      if (!passphrase) {
+        // just grab the last part of it, we don't need the full randomness of uuid
+        passphrase = crypto.randomUUID().split('-')[4];
+        passphraseInUrl = `.${passphrase}`;
+      }
 
       // do the work
       const encryptedBlob = await partage.getEncryptedBlob(file, text, passphrase);
@@ -91,7 +97,7 @@ document.addEventListener('DOMContentLoaded', function() {
           document.getElementById('anotherDiv').removeAttribute('hidden');
           linkDiv.removeAttribute('hidden');
           const link = document.createElement('input');
-          const linkUrl = `${document.location}get#${json.id}-${json.expires_at}`;
+          const linkUrl = `${document.location}get#${json.id}.${json.expires_at}${passphraseInUrl}`;
           link.value = linkUrl;
           link.setAttribute('readonly', 'readonly');
           link.addEventListener('focus', async () => {
@@ -108,7 +114,11 @@ document.addEventListener('DOMContentLoaded', function() {
           linkDiv.innerText = '';
           linkDiv.appendChild(link);
           form.remove();
-          document.getElementById('subtitle').innerText = 'Copy this link and send it with the passphrase';
+          let subtitle = 'Copy this link and send it by email. It is recommended to send the passphrase through a different channel';
+          if (passphraseInUrl) {
+            subtitle = 'Copy this link and send it by email';
+          }
+          document.getElementById('subtitle').innerText = subtitle;
         } else {
           alert(await response.text());
         }
@@ -123,20 +133,30 @@ document.addEventListener('DOMContentLoaded', function() {
   const getForm = document.getElementById("getForm");
   if (getForm) {
     // we slice it to remove the leading '#'
-    const uuid = location.hash.slice(1);
-    const expiresAt = uuid.split('-').pop();
+    const hashParam = location.hash.slice(1);
+    const splitParams = hashParam.split('.');
+    const uuid = splitParams[0];
+    const expiresAt = splitParams[1];
+    // might be empty
+    const passphraseInUrl = splitParams[2];
+    const passphraseInput = document.querySelector('input[name="passphrase"]');
+    if (passphraseInUrl) {
+      passphraseInput.setAttribute('hidden', 'hidden');
+      document.querySelector('.toggle-eye').setAttribute('hidden', 'hidden');
+      passphraseInput.value = passphraseInUrl;
+    }
     const expiresAtEl = document.getElementById('expiresAt');
     expiresAtEl.innerText = `Expires ${formatUnixTimestamp(expiresAt)}`;
     getForm.addEventListener("submit", async (event) => {
       event.preventDefault();
-      const passphrase = document.querySelector('input[name="passphrase"]').value;
+      const passphrase = passphraseInput.value;
       if (!passphrase || !uuid) {
         alert("Please provide both a passphrase and UUID.");
         return;
       }
       try {
         // Fetch the encrypted file as an ArrayBuffer.
-        const response = await fetch(`/api/v1/part/${uuid}`);
+        const response = await fetch(`/api/v1/part/${uuid}.${expiresAt}`);
         if (!response.ok) {
           alert("Failed to download file. Maybe it is expired?");
           return;

--- a/src/main.go
+++ b/src/main.go
@@ -67,7 +67,7 @@ var siteUrl = "http://localhost"
 // uuidv7TimestampRegex ensures that the filename follows the format:
 // UUID with version 7 (third group starts with '7') and then a hyphen and a Unix timestamp.
 // For example: "123e4567-e89b-7d89-a456-426614174000-1678932930"
-var uuidv7TimestampRegex = regexp.MustCompile(`^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-7[a-fA-F0-9]{3}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}-\d+$`)
+var uuidv7TimestampRegex = regexp.MustCompile(`^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-7[a-fA-F0-9]{3}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}.\d+$`)
 
 // partageKey holds the randomly generated key
 var partageKey string
@@ -193,7 +193,7 @@ func postHandler(w http.ResponseWriter, r *http.Request) {
 
 	// For demonstration, write the uploaded file to disk.
 	// In production, this could be stored in a database or object storage.
-	destFilePath := storageDirectory + "/" + part.Id + "-" + strconv.FormatInt(ts, 10)
+	destFilePath := storageDirectory + "/" + part.Id + "." + strconv.FormatInt(ts, 10)
 	dst, err := os.Create(destFilePath)
 	if err != nil {
 		http.Error(w, "Error creating file: "+err.Error(), http.StatusInternalServerError)
@@ -297,16 +297,16 @@ func cleanExpiredFiles(folder string) error {
 		}
 		fileName := entry.Name()
 
-		// Split the filename on "-" and get the last part.
-		parts := strings.Split(fileName, "-")
+		// Split the filename on "-" and get the timestamp part.
+		parts := strings.Split(fileName, ".")
 		if len(parts) < 2 {
 			// Skip files that don't match the expected naming pattern.
 			continue
 		}
-		lastPart := parts[len(parts)-1]
+		tsPart := parts[1]
 
 		// Parse the resulting string as a Unix timestamp.
-		timestamp, err := strconv.ParseInt(lastPart, 10, 64)
+		timestamp, err := strconv.ParseInt(tsPart, 10, 64)
 		if err != nil {
 			errorLogger.Printf("skipping file %q: error parsing timestamp: %v\n", fileName, err)
 			continue


### PR DESCRIPTION
* if no passphrase is provided, use the last part of an uuidv4 (most random part) to generate a passphrase, and add it to the URL
* mask passphrase input if passphrase is present in url
* breaking change: use . as separator in hash part of url for different parts: id/expires/passphrase